### PR TITLE
Fix 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ $(BUILD_FOLDER)/%.o: %.c %.h
 
 
 test: $(test_src) $(LIB) 
-	$(CC) $(CFLAGS) -g $^ -I$(INCLUDE_FOLDER) -o  Testes/main  -pthread -lcheck -pthread -lrt -lm 
+	$(CC) $(CFLAGS) -g $^ -I$(INCLUDE_FOLDER) -o  Testes/main  -pthread -lcheck -pthread -lrt -lm -lsubunit
+
 	@echo "Running Tests"
 	./Testes/main
 


### PR DESCRIPTION
The command `make test` was not working properly because the 'subunit_lfun' was not linked causing the following error:

`Building library
Done
Copying includes to include dir
gcc -Wall -g -g Testes/teste_queue.c Testes/teste_bst.c Testes/teste_treap.c Testes/teste_priority_queue.c Testes/teste_avl_tree.c Testes/teste_stack.c Testes/teste_ordenacao.c Testes/teste_deque.c Testes/teste_list.c Testes/teste_dlist.c Testes/teste_main.c lib/libeda.a -Iinclude -o  Testes/main  -pthread -lcheck -pthread -lrt -lm 
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libcheck.a(check_log.o): na função "subunit_lfun":
(.text+0x5f4): referência não definida para "subunit_test_start"
/usr/bin/ld: (.text+0x6bf): referência não definida para "subunit_test_fail"
/usr/bin/ld: (.text+0x6d4): referência não definida para "subunit_test_pass"
/usr/bin/ld: (.text+0x6ef): referência não definida para "subunit_test_error"
collect2: error: ld returned 1 exit status
make: *** [Makefile:55: test] Erro 1
`